### PR TITLE
feat: add showIndex option to TableOfContents component and TOC gener…

### DIFF
--- a/astro/TableOfContents.astro
+++ b/astro/TableOfContents.astro
@@ -1,13 +1,14 @@
 ---
 interface Props {
-    title?: string;
-    backgroundColor?: string;
-    class?: string;
+  title?: string;
+  showIndex?: boolean;
+  backgroundColor?: string;
+  class?: string;
 }
-const { title, backgroundColor, class:className, ...rest } = Astro.props;
+const { title, backgroundColor, class:className, showIndex, ...rest } = Astro.props;
 ---
 
-<stron-toc class={className} {...rest}>
+<stron-toc class={className} {...rest} data-show-index={showIndex ? 'true' : 'false'}>
     <h2 id="toc-title" style={`background-color: ${backgroundColor || 'transparent'};`}>
         {title || ''}
     </h2>
@@ -54,7 +55,7 @@ const { title, backgroundColor, class:className, ...rest } = Astro.props;
             font-weight: 700;
             &:hover {
                 color: #777777;
-                text-decoration: underline;
+              text-decoration: underline;
             }
         }
         &.collapsed {
@@ -62,17 +63,38 @@ const { title, backgroundColor, class:className, ...rest } = Astro.props;
             overflow: hidden;
             transition: max-height 0.3s ease;
         }
+      
     }
+    stron-toc[data-show-index="true"]{ 
+      & a::before {
+          --data-index: attr(data-index);
+          content: var(--data-index);
+          margin-right: 0.5rem;
+          color:currentColor;;
+      }
+    }
+
 </style>
 
 <script>
     const toc = document.querySelector('stron-toc');
-
+    const stronToc = document.querySelector('stron-toc');
     const titleElement = toc?.querySelector('#toc-title');
+
+    const showIndexPreferences = stronToc?.getAttribute('data-show-index');
+    
+    if (!showIndexPreferences) {
+      stronToc?.setAttribute('data-show-index', showIndex() ? 'true' : 'false');
+    }
 
     titleElement?.addEventListener('click', (e) => {
         e.preventDefault();
         toc?.classList.toggle('collapsed');
     });
+
+    function showIndex() {
+      //@ts-ignore
+      return ( typeof tocConfig !== 'undefined' && tocConfig.showIndex === true );
+    }
 
 </script>

--- a/src/generator/toc-generator.test.ts
+++ b/src/generator/toc-generator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { generateToc, buildHierarchy } from './toc-generator';
+import { generateToc, buildHtmlHierarchy } from './toc-generator';
 import { tocContainerTemplate } from '../templates/html-templates';
+import { createHierarchy } from '../parser/heading-parser';
 
 describe('generateToc', () => {
     it('should generate hierarchical HTML TOC from parsed headings', () => {
@@ -14,20 +15,21 @@ describe('generateToc', () => {
 
         const expectedHtml =
             `<ul>` +
-            `<li><a href="#introduction">Introduction</a>` +
+            `<li><a data-index="1" href="#introduction">Introduction</a>` +
             `<ul>` +
-            `<li><a href="#getting-started">Getting Started</a></li>` +
-            `<li><a href="#installation">Installation</a>` +
+            `<li><a data-index="1.1" href="#getting-started">Getting Started</a></li>` +
+            `<li><a data-index="1.2" href="#installation">Installation</a>` +
             `<ul>` +
-            `<li><a href="#using-npm">Using npm</a></li>` +
-            `<li><a href="#using-yarn">Using yarn</a></li>` +
+            `<li><a data-index="1.2.1" href="#using-npm">Using npm</a></li>` +
+            `<li><a data-index="1.2.2" href="#using-yarn">Using yarn</a></li>` +
             `</ul></li>` +
             `</ul></li>` +
             `</ul>`;
 
-        expect(buildHierarchy(headings)).toEqual({
+        const herarchyResult = buildHtmlHierarchy(createHierarchy(headings));
+
+        expect(herarchyResult).toEqual({
             html: expectedHtml,
-            nextIndex: headings.length,
         });
     });
 
@@ -35,9 +37,8 @@ describe('generateToc', () => {
         const headings: any[] = [];
         const expectedHtml = `<ul></ul>`;
 
-        expect(buildHierarchy(headings)).toEqual({
+        expect(buildHtmlHierarchy(headings)).toEqual({
             html: expectedHtml,
-            nextIndex: 0,
         });
     });
 
@@ -55,16 +56,16 @@ describe('generateToc', () => {
 
         let expectedHtml =
             `<ul>` +
-            `<li><a href="#introduction">Introduction</a>` +
+            `<li><a data-index="1" href="#introduction">Introduction</a>` +
             `<ul>` +
-            `<li><a href="#getting-started">Getting Started</a></li>` +
-            `<li><a href="#installation">Installation</a>` +
+            `<li><a data-index="1.1" href="#getting-started">Getting Started</a></li>` +
+            `<li><a data-index="1.2" href="#installation">Installation</a>` +
             `<ul>` +
-            `<li><a href="#using-npm">Using npm</a></li>` +
-            `<li><a href="#using-yarn">Using yarn</a></li>` +
+            `<li><a data-index="1.2.1" href="#using-npm">Using npm</a></li>` +
+            `<li><a data-index="1.2.2" href="#using-yarn">Using yarn</a></li>` +
             `</ul></li>` +
             `</ul></li>` +
-            `<li><a href="#another-introduction">Another Introduction</a></li>` +
+            `<li><a data-index="2" href="#another-introduction">Another Introduction</a></li>` +
             `</ul>`;
 
         expectedHtml = tocContainerTemplate(expectedHtml);
@@ -91,11 +92,11 @@ describe('generateToc', () => {
 
         let expectedHtml =
             `<ul>` +
-            `<li><a href="#introduction-overview">Introduction & Overview</a>` +
+            `<li><a data-index="1" href="#introduction-overview">Introduction & Overview</a>` +
             `<ul>` +
-            `<li><a href="#getting-started-a-guide">Getting Started: A Guide</a>` +
+            `<li><a data-index="1.1" href="#getting-started-a-guide">Getting Started: A Guide</a>` +
             `<ul>` +
-            `<li><a href="#using-npm-yarn">Using npm & yarn</a></li>` +
+            `<li><a data-index="1.1.1" href="#using-npm-yarn">Using npm & yarn</a></li>` +
             `</ul></li>` +
             `</ul></li>` +
             `</ul>`;

--- a/src/generator/toc-generator.ts
+++ b/src/generator/toc-generator.ts
@@ -1,7 +1,16 @@
 import type { TocOptions, HeadingData, HierarchyResult } from '../types/index';
-import { parseHeadings } from '../parser/heading-parser';
+import { createHierarchy, HeadingNode, parseHeadings } from '../parser/heading-parser';
 import { tocContainerTemplate, nestedListTemplate } from '../templates/html-templates';
 
+
+/**
+ * Checks if the current heading has child headings.
+ *
+ * @param {HeadingData[]} headings - The array of heading data.
+ * @param {number} currentIndex - The current index of the heading being processed.
+ * @param {number} currentLevel - The current heading level being processed.
+ * @returns {boolean} True if the current heading has child headings, false otherwise.
+ */
 function hasChildHeadings(
     headings: HeadingData[],
     currentIndex: number,
@@ -11,12 +20,20 @@ function hasChildHeadings(
     return nextIndex < headings.length && headings[nextIndex].level > currentLevel;
 }
 
+/**
+ * Processes a heading with child headings and generates the corresponding HTML.
+ *
+ * @param {HeadingData[]} headings - The array of heading data.
+ * @param {number} currentIndex - The current index of the heading being processed.
+ * @param {HeadingData} heading - The heading data to process.
+ * @returns {{ html: string; nextIndex: number }} An object containing the generated HTML and the next index to process.
+ */
 function processHeadingWithChildren(
     headings: HeadingData[],
     currentIndex: number,
     heading: HeadingData,
 ): { html: string; nextIndex: number } {
-    const openTag = `<li><a href="#${heading.id}">${heading.title}</a>`;
+    const openTag = `<li><a data-index="${heading.indexId}.${currentIndex}" href="#${heading.id}">${heading.title}</a>`;
     const childResult = buildHierarchy(headings, currentIndex + 1, heading.level + 1);
     const closeTag = '</li>';
 
@@ -26,13 +43,28 @@ function processHeadingWithChildren(
     };
 }
 
-function processHeadingWithoutChildren(heading: HeadingData): { html: string; nextIndex: number } {
+/**
+ * Processes a heading without child headings and generates the corresponding HTML.
+ *
+ * @param {HeadingData} heading - The heading data to process.
+ * @returns {{ html: string; nextIndex: number }} An object containing the generated HTML and the next index to process.
+ */
+function processHeadingWithoutChildren({id, title, indexId}: HeadingData): { html: string; nextIndex: number } {
     return {
-        html: `<li><a href="#${heading.id}">${heading.title}</a></li>`,
+        html: `<li><a data-index="${indexId}" href="#${id}">${title}</a></li>`,
         nextIndex: 1,
     };
 }
 
+/** 
+ * @depecated Use `buildHtmlHierarchy` instead.
+ * Builds a hierarchical HTML structure from the given headings.
+ *
+ * @param {HeadingData[]} headings - The array of heading data.
+ * @param {number} startIndex - The starting index for processing headings.
+ * @param {number} currentLevel - The current heading level being processed.
+ * @returns {HierarchyResult} An object containing the generated HTML and the next index to process.
+ */
 export function buildHierarchy(
     headings: HeadingData[],
     startIndex = 0,
@@ -68,10 +100,54 @@ export function buildHierarchy(
     };
 }
 
+/**
+ * Builds a hierarchical HTML structure from the given heading nodes.
+ *
+ * @param {HeadingNode[]} headings - The array of heading nodes.
+ * @param {number[]} indexAcc - The accumulated index for nested headings.
+ * @returns {{ html: string; }} An object containing the generated HTML.
+ */
+export function buildHtmlHierarchy(headings: HeadingNode[], indexAcc: number[] = []): { html: string; } {
+  let html = '';
+  if (headings.length === 0) return { html: nestedListTemplate(html) };
+  
+  for (const { indexId, id, title, children, parentIndex } of headings) {
+    let newIndex = hasParentIndex(parentIndex) ? [...indexAcc, (indexId || 0)] : [indexId || 0]; 
+
+    let index =  newIndex.join('.');
+
+    if (children.length > 0) {
+      const childResult = buildHtmlHierarchy(children, newIndex);
+      html += `<li><a data-index="${index}" href="#${id}">${title}</a>${childResult.html}</li>`;
+      continue;
+    }
+    html += `<li><a data-index="${index}" href="#${id}">${title}</a></li>`;
+  }
+  return {html: nestedListTemplate(html)};
+}
+
+
+/**
+ * Checks if the given parent index is defined (not null or undefined).
+ *
+ * @param {number | undefined | null} parentIndex - The parent index to check.
+ * @returns {boolean} True if the parent index is defined, false otherwise.
+ */
+function hasParentIndex(parentIndex: number | undefined | null ): boolean {
+  return parentIndex !== null && parentIndex !== undefined;
+}
+
+
+/**
+ * Generates a Table of Contents (TOC) from the given page content.
+ *
+ * @param {TocOptions} page - The page options containing the content to generate the TOC from.
+ * @returns {string} The generated TOC HTML.
+ */
 export function generateToc(page: TocOptions): string {
     const parsedHeadings = parseHeadings(page.content);
     if (parsedHeadings.length === 0) return '';
-
-    const result = buildHierarchy(parsedHeadings);
+    const headings = createHierarchy(parsedHeadings);
+    const result = buildHtmlHierarchy(headings);
     return tocContainerTemplate(result.html);
 }

--- a/src/hooks/register-toc-integration.ts
+++ b/src/hooks/register-toc-integration.ts
@@ -6,6 +6,7 @@ export function registerTocIntegration(tocConfig: TocConfig) {
         config,
         updateConfig,
         addMiddleware,
+      injectScript,
         command,
         logger,
     }: Parameters<BaseIntegrationHooks['astro:config:setup']>[0]) => {
@@ -20,6 +21,10 @@ export function registerTocIntegration(tocConfig: TocConfig) {
                 hooks: {},
             });
         }
+
+        injectScript('head-inline', `
+            const tocConfig = { showIndex: ${tocConfig.showIndex} };  
+          `)
         logger.info('Registering Table of Contents integration');
         logger.info('Adding TOC...');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,11 @@
-// Main integration export
 export { tableOfContents } from './integration/astro-integration';
 
-// Export generation utilities
 export { generateToc } from './generator/toc-generator';
 
-// Export templates
 export {
     tocItemTemplate,
     tocContainerTemplate,
     nestedListTemplate
 } from './templates/html-templates';
 
-// Export types
 export type { TocOptions, HeadingData, HierarchyResult } from './types';

--- a/src/integration/astro-integration.test.ts
+++ b/src/integration/astro-integration.test.ts
@@ -1,1 +1,0 @@
-// Integration tests for Astro TOC integration

--- a/src/middleware/toc-middleware.test.ts
+++ b/src/middleware/toc-middleware.test.ts
@@ -1,1 +1,0 @@
-// Tests for TOC middleware functionality

--- a/src/parser/heading-parser.test.ts
+++ b/src/parser/heading-parser.test.ts
@@ -1,1 +1,0 @@
-// Tests for HTML heading parser

--- a/src/parser/heading-parser.ts
+++ b/src/parser/heading-parser.ts
@@ -14,7 +14,6 @@ export function parseHeadings(content: string): HeadingData[] {
         .map((heading) => {
             const level = extractHeadingLevel(heading);
             const title = extractHeadingTitle(heading);
-
             return {
                 level,
                 title,
@@ -22,4 +21,38 @@ export function parseHeadings(content: string): HeadingData[] {
             };
         })
         .filter((heading) => heading.title.trim().length > 0);
+}
+
+export type HeadingNode = HeadingData & { children: HeadingNode[] };
+
+/**
+ * Creates a hierarchical structure of headings from a flat array of heading data.
+ *
+ * @param {HeadingData[]} headings - The flat array of heading data.
+ * @returns {HeadingNode[]} A hierarchical structure of heading nodes.
+ */
+export function createHierarchy(headings: HeadingData[]): HeadingNode[] {
+    const root: HeadingNode[] = [];
+    const stack: HeadingNode[] = [];
+
+    for (const heading of headings) {
+        const node: HeadingNode = { ...heading, children: [] };
+
+        while (stack.length > 0 && stack[stack.length - 1].level >= node.level) {
+            stack.pop();
+        }
+
+        stack.length === 0 ? root.push({
+            ...node,
+            indexId: root.length + 1,
+            parentIndex: null,
+        }) : stack[stack.length - 1].children.push({
+            ...node,
+            parentIndex: stack.length,
+            indexId: stack[stack.length - 1].children.length + 1,
+        });
+        stack.push(node);
+    }
+
+    return root;
 }

--- a/src/templates/html-templates.test.ts
+++ b/src/templates/html-templates.test.ts
@@ -1,1 +1,0 @@
-// Tests for HTML templates and formatting

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,8 @@ export interface HeadingData {
     level: number;
     title: string;
     id: string;
+    parentIndex?: number | null;
+    indexId?: number;
 }
 
 export interface HierarchyResult {
@@ -17,6 +19,7 @@ export interface HierarchyResult {
 
 export interface TocConfig {
     title?: string;
+    showIndex?: boolean;
     position?: 'left' | 'right';
     collapsible?: boolean;
     maxDepth?: number;


### PR DESCRIPTION
This pull request introduces hierarchical index numbering for Table of Contents (TOC) entries, enabling numbered TOCs (e.g., "1", "1.1", "1.2") and the ability to toggle index display via configuration. The changes include enhancements to TOC HTML generation, new hierarchical heading parsing, configuration propagation, and the necessary UI and style updates. Several files are refactored for clarity, and tests are updated to reflect the new structure.

**TOC Indexing and Hierarchy Improvements:**

- Added hierarchical index numbers to TOC entries by introducing `indexId` and `parentIndex` fields in the `HeadingData` type and generating nested index values (e.g., "1", "1.2.1") in TOC HTML output. This is accomplished by the new `createHierarchy` function and the refactored `buildHtmlHierarchy` function, replacing the old flat `buildHierarchy` approach. 
- Updated TOC HTML generation so that each TOC link includes a `data-index` attribute with its hierarchical index, and tests are updated to expect these attributes. 

**Configuration and Integration:**

- Added a `showIndex` boolean option to `TocConfig`, and propagated it through the integration, template, and runtime script. The option is injected into the page so the component can conditionally display index numbers. 

**Component and Style Updates:**

- Updated the `TableOfContents.astro` component to accept a `showIndex` prop, set the `data-show-index` attribute, and use CSS to display index numbers before each link when enabled.

**Refactoring and Cleanup:**

- Deprecated the old `buildHierarchy` function in favor of the new, more robust `buildHtmlHierarchy` and `createHierarchy` approach for better maintainability and clarity. 

**Test and Type Updates:**

- Updated type definitions for headings and configuration to support new fields. Tests for generators, templates, parsers, and middleware are updated or cleaned up to align with the new structure. 

These changes together provide a more flexible and feature-rich Table of Contents, supporting hierarchical numbering and improved integration with Astro projects.